### PR TITLE
Timeout First Draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ InstalledFiles
 _yardoc
 coverage
 doc/
+log/
 lib/bundler/man
 pkg
 rdoc

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format progress

--- a/lib/timeout/extensions.rb
+++ b/lib/timeout/extensions.rb
@@ -1,13 +1,8 @@
 require 'timeout/version'
-require 'timeout/extensions'
 
 class Thread
   attr_accessor :timeout_handler
   attr_accessor :sleep_handler
-
-  def self.enhance_for_concurrency!
-    yield Thread.current if block_given?
-  end
 end
 
 module Timeout::Extensions
@@ -48,4 +43,3 @@ end
 
 Timeout.extend Timeout::Extensions
 include Kernel::Extensions
-

--- a/lib/timeout/extensions.rb
+++ b/lib/timeout/extensions.rb
@@ -1,5 +1,51 @@
 require 'timeout/version'
+require 'timeout/extensions'
 
-module Timeout
-  # Your code goes here...
+class Thread
+  attr_accessor :timeout_handler
+  attr_accessor :sleep_handler
+
+  def self.enhance_for_concurrency!
+    yield Thread.current if block_given?
+  end
 end
+
+module Timeout::Extensions
+  def self.extended(mod)
+    mod.singleton_class.class_eval do
+      alias_method :timeout_without_handler, :timeout
+      alias_method :timeout, :timeout_with_handler
+    end
+  end
+
+  def timeout_with_handler(*args, &block)
+    if timeout_handler = Thread.current.timeout_handler
+      timeout_handler.call(*args, &block)
+    else
+      timeout_without_handler(*args, &block)
+    end
+  end
+  module_function :timeout_with_handler
+  public :timeout_with_handler
+end
+
+module Kernel::Extensions
+  def self.included(mod)
+    mod.class_eval do
+      alias_method :sleep_without_handler, :sleep
+      alias_method :sleep, :sleep_with_handler
+    end
+  end
+
+  def sleep_with_handler(*args)
+    if sleep_handler = Thread.current.sleep_handler
+      sleep_handler.call(*args)
+    else
+      sleep_without_handler(*args)
+    end
+  end
+end
+
+Timeout.extend Timeout::Extensions
+include Kernel::Extensions
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,63 @@
+require 'rubygems'
+require 'bundler/setup'
+require 'logger'
+require 'timeout'
+require 'timeout/extensions'
+require 'celluloid/rspec'
+
+logfile = File.open(File.expand_path("../../log/test.log", __FILE__), 'a')
+logfile.sync = true
+
+logger = Celluloid.logger = Logger.new(logfile)
+
+Celluloid.shutdown_timeout = 1 
+
+
+class Celluloid::Actor
+  # Important that these two are left out, or else
+  # timeout calls inside the actor scope will never propagate
+  # to the proper extensions
+  undef_method :timeout
+  undef_method :sleep
+end
+
+
+RSpec.configure do |config|
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+
+  config.before do
+    Celluloid.logger = logger
+    if Celluloid.running?
+      Celluloid.shutdown
+      sleep 0.01
+      Celluloid.internal_pool.assert_inactive
+    end
+
+    Celluloid.boot
+
+    FileUtils.rm("/tmp/cell_sock") if File.exist?("/tmp/cell_sock")
+    include Timeout::Extensions
+  end
+
+  config.order = 'random'
+end
+
+class ExampleActor
+  include Celluloid
+  execute_block_on_receiver :wrap
+
+  def wrap
+    yield
+  end
+end
+
+def within_actor(&block)
+  actor = ExampleActor.new
+  actor.wrap(&block)
+ensure
+  actor.terminate if actor and actor.alive?
+end
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,9 @@ class Celluloid::Actor
   # Important that these two are left out, or else
   # timeout calls inside the actor scope will never propagate
   # to the proper extensions
-  undef_method :timeout
-  undef_method :sleep
+  # TODO: eventually remove this if celluloid adopts the gem
+  undef_method :timeout if instance_methods(false).include?(:timeout)
+  undef_method :sleep if instance_methods(false).include?(:sleep)
 end
 
 

--- a/spec/timeout/extensions_spec.rb
+++ b/spec/timeout/extensions_spec.rb
@@ -8,9 +8,7 @@ describe Timeout::Extensions do
     context "inside and outside of actor" do
       it "hits the proper timeout handler" do
         within_actor do
-          Thread.enhance_for_concurrency! do |t|
-            t.timeout_handler = dummy_timeout
-          end
+          Thread.current.timeout_handler = dummy_timeout
           expect(dummy_timeout).to receive(:call).with(2, exception, &action)
           timeout(2, exception, &action)
         end
@@ -25,9 +23,7 @@ describe Timeout::Extensions do
     context "inside and outside of actor" do
       it "hits the proper sleep handler" do
         within_actor do
-          Thread.enhance_for_concurrency! do |t|
-            t.sleep_handler = dummy_sleep
-          end
+          Thread.current.sleep_handler = dummy_sleep
           expect(dummy_sleep).to receive(:call).with(2)
           sleep(2)
         end

--- a/spec/timeout/extensions_spec.rb
+++ b/spec/timeout/extensions_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Timeout::Extensions do
+  describe "timeout" do
+    let(:dummy_timeout) { double(:meta_timeout) }
+    let(:exception) { double(:exception) }
+    let(:action) { Proc.new{ |t|  } }
+    context "inside and outside of actor" do
+      it "hits the proper timeout handler" do
+        within_actor do
+          Thread.enhance_for_concurrency! do |t|
+            t.timeout_handler = dummy_timeout
+          end
+          expect(dummy_timeout).to receive(:call).with(2, exception, &action)
+          timeout(2, exception, &action)
+        end
+        expect(Timeout).to receive(:timeout_without_handler)
+        timeout(2, exception, &action)
+      end
+    end
+  end
+
+  describe "sleep" do
+    let(:dummy_sleep) { double(:meta_sleep) }
+    context "inside and outside of actor" do
+      it "hits the proper sleep handler" do
+        within_actor do
+          Thread.enhance_for_concurrency! do |t|
+            t.sleep_handler = dummy_sleep
+          end
+          expect(dummy_sleep).to receive(:call).with(2)
+          sleep(2)
+        end
+        expect(self).to receive(:sleep_without_handler)
+        sleep(2)
+      end
+    end
+  end 
+end

--- a/timeout.gemspec
+++ b/timeout.gemspec
@@ -6,7 +6,7 @@ require 'timeout/version'
 Gem::Specification.new do |spec|
   spec.name          = "timeout"
   spec.version       = Timeout::VERSION
-  spec.authors       = ["Tony Arcieri"]
+  spec.authors       = ["Tony Arcieri", "Tiago Cardoso"]
   spec.email         = ["bascule@gmail.com"]
   spec.summary       = "Extensions to the Ruby standard library's timeout API"
   spec.description   = "A timeout extension for Ruby which plugs into multiple timeout backends"
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", 		"~> 10.4.2"
+  spec.add_development_dependency "pry",		"~> 0.10.1"
+  spec.add_development_dependency "pry-debugger"
+  spec.add_development_dependency "rspec", 	 	"~> 2.14.0"
+  spec.add_development_dependency "celluloid", 		"~> 0.15.0"
 end

--- a/timeout.gemspec
+++ b/timeout.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'timeout/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "timeout"
+  spec.name          = "timeout-extensions"
   spec.version       = Timeout::VERSION
   spec.authors       = ["Tony Arcieri", "Tiago Cardoso"]
   spec.email         = ["bascule@gmail.com"]


### PR DESCRIPTION
@tarcieri , this is the first draft of a possible implementation of the timeout gem. As discussed [here](https://github.com/celluloid/celluloid-io/issues/97), I've followed the approach of having handlers inside the Thread class. 

As first proposal I would probably rename this to "time-extensions" instead of "timeout", since there's already a "timeout" to require (the standard lib "timeout") which would conflict, and because this not only about timeout anymore (it patches sleep as well). 

The main drawback I see here is that sleep extension is included in global space. Since sleep is implemented in C and not really inside Kernel module, there is not a proper way of doing this, at least in plain ruby. Is there a way to work this around?

Inclusion of this gem into celluloid would involve removinf the #timeout and #sleep methods from the Actor class. They would then be the handlers which would extend the threads inside the Celluloid pool. 